### PR TITLE
pass package nickname to new_package handler

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -247,7 +247,8 @@ Client.prototype.on_swank_message = function(msg) {
     var presentation_id = sexp.children[1].source;
     this.on_handlers.presentation_end(presentation_id);
   } else if (cmd == ":new-package") {
-    this.on_handlers.new_package(util.from_lisp_string(sexp.children[1]));
+    this.on_handlers.new_package(util.from_lisp_string(sexp.children[1]),
+      util.from_lisp_string(sexp.children[2]));
   } else if (cmd == ":debug") {
     this.debug_setup_handler(sexp);
   } else if (cmd == ":debug-activate") {


### PR DESCRIPTION
This is such that user of the library can use the shorter nickname to display in prompt.

BTW, didn't realize you're also bugged by me for `linear-programming`! :D

I'm using the library to develop a swank-based VSCode extension. I expect to fix stuff along the way and happy to co-maintain this as well if you're ok with giving commit access; or I can generate PRs, no pressure :)